### PR TITLE
Fix typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ file into a userspace buffer, then write that buffer to the socket via
 
 .. code-block:: python
 
-    # how a file is tipically sent
+    # how a file is typically sent
 
     import socket
 


### PR DESCRIPTION
Just a small thing I noticed while reading docs, single letter typo.